### PR TITLE
Add .gitignore file to exclude files from being tracked by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# python cache files
+*.pyc*
+
+# ckan tracking file
+/ckanext_faoclh.egg-info


### PR DESCRIPTION
### what does the PR do
- Adds a .gitignore file to exclude some files from being tracked by git

### issue 
[#39](https://github.com/geosolutions-it/ckanext-faoclh/issues/39)