### PR TITLE
remove scroll effect from 'Update dataset' button in dataset edit page

### DIFF
--- a/ckanext/faoclh/public/base/css/main.css
+++ b/ckanext/faoclh/public/base/css/main.css
@@ -7669,8 +7669,8 @@ select[multiple].control-large input {
 .form-actions .control-required-message:first-child {
   margin-left: 0;
 }
-.form-actions {
-  overflow: auto;
+article.module .form-actions {
+  overflow: unset;
 }
 @media (min-width: 768px) {
   .form-actions {


### PR DESCRIPTION
#### what does the PR do
- Removes scrolling from parent element of "update dataset" / "next: add dataset" button in the dataset edit/create page.