### PR TITLE
change default images for vocabs in home page

### DIFF
--- a/ckanext/faoclh/templates/home/snippets/fao_item_summary.html
+++ b/ckanext/faoclh/templates/home/snippets/fao_item_summary.html
@@ -4,7 +4,7 @@
         {% if (thumbnail)%}
         <div class="fao-item-thumbnail" style="background-image: url('{{ thumbnail }}')"></div>
         {% else %}
-        <div class="fao-item-thumbnail"></div>
+        <div class="fao-item-thumbnail" style="background-image: url('{{ h.url_for_static('/base/images/ckan-logo.png') }}'); background-size: 85% 50%; background-color: #0f68a7;"></div>
         {% endif %}
         <div class="fao-item-title">
             <h3 title="{{ title }}">{{ h.truncate(title, length=45, whole_word=True) }}</h3>

--- a/ckanext/faoclh/templates/home/snippets/geographic_focus.html
+++ b/ckanext/faoclh/templates/home/snippets/geographic_focus.html
@@ -21,7 +21,7 @@
                 title=h.fao_voc_label('fao_geographic_focus', item.name) or item.display_name,
                 dataset_url=url,
                 dataset_count= item.count,
-                thumbnail=item.thumbnail or thumbnails[item.name] or h.url_for_static('/base/images/fao/thumbnail-placeholder.png') %}
+                thumbnail=item.thumbnail or thumbnails[item.name] %}
         {% endfor %}
     </div>
 </div>

--- a/ckanext/faoclh/templates/home/snippets/kind_of_activities.html
+++ b/ckanext/faoclh/templates/home/snippets/kind_of_activities.html
@@ -21,7 +21,7 @@
                 title=h.fao_voc_label('fao_activity_type', item.name) or item.display_name,
                 dataset_url=url,
                 dataset_count= item.count,
-                thumbnail=item.thumbnail or thumbnails[item.name] or h.url_for_static('/base/images/fao/thumbnail-placeholder.png') %}
+                thumbnail=item.thumbnail or thumbnails[item.name] %}
         {% endfor %}
     </div>
 </div>

--- a/ckanext/faoclh/templates/home/snippets/topics.html
+++ b/ckanext/faoclh/templates/home/snippets/topics.html
@@ -22,7 +22,7 @@
                 title=topic.title,
                 dataset_url=url,
                 dataset_count= topic.package_count,
-                thumbnail=topic.image_display_url or h.url_for_static('/base/images/fao/thumbnail-placeholder.png') %}
+                thumbnail=topic.image_display_url %}
         {% endfor %}
     </div>
 </div>

--- a/ckanext/faoclh/templates/home/snippets/type_of_resources.html
+++ b/ckanext/faoclh/templates/home/snippets/type_of_resources.html
@@ -21,7 +21,7 @@
                 title=h.fao_voc_label('fao_resource_type', item.name) or item.display_name,
                 dataset_url=url,
                 dataset_count= item.count,
-                thumbnail=item.thumbnail or thumbnails[item.name] or h.url_for_static('/base/images/fao/thumbnail-placeholder.png') %}
+                thumbnail=item.thumbnail or thumbnails[item.name] %}
         {% endfor %}
     </div>
 </div>


### PR DESCRIPTION
#### what does the PR do
- Uses FAO logo as default for cards in the home page with missing images

#### changes made
- Added FAO logo as default for missing images in home page cards
- styled the tag to fit the card