### PR TITLE
[Fixes #79] Year of Release Resource Field

### DIFF
--- a/ckanext/faoclh/plugin.py
+++ b/ckanext/faoclh/plugin.py
@@ -3,6 +3,7 @@
 '''plugin.py
 
 '''
+from datetime import datetime
 import logging
 import json
 import os
@@ -242,7 +243,8 @@ class FAOCLHGUIPlugin(plugins.SingletonPlugin,
             'fao_get_search_facet': fao_get_search_facet,
             'contains_active_facets': contains_active_facets,
             'get_tag_image_url': TagImageUrl.get,
-            'fao_get_org_image_url': fao_get_org_image_url
+            'fao_get_org_image_url': fao_get_org_image_url,
+            'fao_get_current_year': lambda: str(datetime.now().year),
         }
 
 

--- a/ckanext/faoclh/templates/package/resource_read.html
+++ b/ckanext/faoclh/templates/package/resource_read.html
@@ -35,7 +35,7 @@
               {% for key, value in h.format_resource_items(res.items()) %}
 		{% if key in ('custom resource text') %}
 
-                  <tr class="toggle-more"><th scope="row">{{ 'Year of Release' }}</th><td>{{ value }}</td></tr>
+                  <tr class="toggle-more"><th scope="row">{{ 'Year of Release' }}</th><td>{{res.custom_resource_text}}</td></tr>
 		{% endif %}
 		{% if key not in ('custom resource text', 'format', 'has views', 'id', 'package id', 'revision id', 'state') %} <!-- NON VISUALIZZA GLI ITEMS in lista-->
 		  <tr class="toggle-more"><th scope="row">{{ key }}</th><td>{{ value }}</td></tr>

--- a/ckanext/faoclh/templates/package/snippets/resource_form.html
+++ b/ckanext/faoclh/templates/package/snippets/resource_form.html
@@ -18,7 +18,7 @@
 <script>
 window.addEventListener("load", function(){
      $("#field-custom_resource_text").on("keydown", function(event){
-         if (event.key === '.' || event.key === '+' || event.key === '-'){
+         if (event.key === '.' || event.key === '+' || event.key === '-' || event.key.toLowerCase() === 'e'){
              return false;
          }
         const elem = document.getElementById('field-custom_resource_text');

--- a/ckanext/faoclh/templates/package/snippets/resource_form.html
+++ b/ckanext/faoclh/templates/package/snippets/resource_form.html
@@ -22,7 +22,7 @@ window.addEventListener("load", function(){
              return false;
          }
         const elem = document.getElementById('field-custom_resource_text');
-         if (elem.value.length != {{ h.fao_get_current_year() | length }}){
+         if (elem.value.length && elem.value.length != {{ h.fao_get_current_year() | length }}){
              elem.setCustomValidity("Enter a valid year in the format YYYY.");
          }
          else {

--- a/ckanext/faoclh/templates/package/snippets/resource_form.html
+++ b/ckanext/faoclh/templates/package/snippets/resource_form.html
@@ -10,10 +10,26 @@
             <div class="controls ">
                 <input id="field-custom_resource_text" type="number" min="1900" max="{{ h.fao_get_current_year() }}"
                        name="custom_resource_text" value="{{ data.custom_resource_text }}" placeholder="{{ _('Year of Release') }}"
-                       class="form-control" step="1" onkeypress="return event.charCode != 46 && event.charCode != 43 && event.charCode != 45 && this.value.length < {{ h.fao_get_current_year()|length }} || event.charCode == 13" />
+                       class="form-control" step="1" />
             </div>
           </div>
       </div>
   </div>
+<script>
+window.addEventListener("load", function(){
+     $("#field-custom_resource_text").on("keydown", function(event){
+         if (event.key === '.' || event.key === '+' || event.key === '-'){
+             return false;
+         }
+        const elem = document.getElementById('field-custom_resource_text');
+         if (elem.value.length != {{ h.fao_get_current_year() | length }}){
+             elem.setCustomValidity("Enter a valid year in the format YYYY.");
+         }
+         else {
+             elem.setCustomValidity("");
+         }
+     });
+});
+</script>
 
 {% endblock %}

--- a/ckanext/faoclh/templates/package/snippets/resource_form.html
+++ b/ckanext/faoclh/templates/package/snippets/resource_form.html
@@ -5,11 +5,15 @@
 
   <div class="form-group control-medium">
       <div class="controls">
-          {{ form.input('custom_resource_text', label=_('Year of Release'), id='field-custom_resource_text',
-          placeholder=_('Year of Release'), value=data.custom_resource_text, error=errors.custom_resource_text,
-          classes=['control-medium']) }}
+          <div class="form-group control-medium">
+            <label class="control-label" for="field-custom_resource_text">{{ _('Year of Release') }}</label>
+            <div class="controls ">
+                <input id="field-custom_resource_text" type="number" min="1900" max="{{ h.fao_get_current_year() }}"
+                       name="custom_resource_text" value="{{ data.custom_resource_text }}" placeholder="{{ _('Year of Release') }}"
+                       class="form-control" step="1" onkeypress="return event.charCode != 46 && event.charCode != 43 && event.charCode != 45 && this.value.length < {{ h.fao_get_current_year()|length }} || event.charCode == 13" />
+            </div>
+          </div>
       </div>
   </div>
 
 {% endblock %}
-


### PR DESCRIPTION
Expected Behaviour
--------------------
The custom resource field "year of release" should only allow valid years

What does the Fix:
------------------
- This PR validates that actual years have been used as "year of release" and skips formatting of the "year of release" before it is displayed.

Changes Made
---------------
- I replaced the `form.input` with actual HTML that accepts other values such as max, min and javascript events then validated its values as valid years

Related Issue
-------------
[issue #79](https://github.com/geosolutions-it/ckanext-faoclh/issues/79)