### PR TITLE
[Fixes #81] Small issue on exported datasets

### DIFF
--- a/ckanext/faoclh/controllers/export_dataset_controller.py
+++ b/ckanext/faoclh/controllers/export_dataset_controller.py
@@ -88,7 +88,6 @@ class GetPackageData(Package):
             or_(~Tag.vocabulary_id.in_(custom_vocabs), Tag.vocabulary_id == None)
         ).all()
 
-        logic.get_action(u'package_show')
         return u', '.join([tag[0] for tag in tags])
 
     @classmethod


### PR DESCRIPTION
 Expected Behaviour
--------------------
The dataset export CSV file should not contain custom vocabs in the dataset tag column

What does the Fix:
------------------
- This PR removes the custom vocabularies from the dataset CSV export file

Changes Made
---------------
-  A small tweak to a SQLalchemy query

Related Issue
-------------
[issue #81](https://github.com/geosolutions-it/ckanext-faoclh/issues/81)