### PR TITLE
[Fixes #94] Start a search from 'FAO Specific Info'

### DIFF
--- a/ckanext/faoclh/templates/package/snippets/additional_info.html
+++ b/ckanext/faoclh/templates/package/snippets/additional_info.html
@@ -11,23 +11,34 @@
     <tbody>
 
       {% block extras scoped %}
-
         {% if pkg_dict.fao_resource_type %}
           <tr>
             <th scope="row" class="dataset-label">{{ _("Type of Resource") }}</th>
-            <td class="dataset-details">{{ h.fao_voc_label('fao_resource_type', pkg_dict.fao_resource_type) }}</td>
+            <td class="dataset-details">
+              <a href="{% url_for controller='package', action='search', fao_resource_type=pkg_dict.fao_resource_type[0], _fao_expanded_facets='fao_resource_type' %}">
+                {{ h.fao_voc_label('fao_resource_type', pkg_dict.fao_resource_type) }}
+              </a>
+            </td>
           </tr>
         {% endif %}
         {% if pkg_dict.fao_activity_type %}
           <tr>
             <th scope="row" class="dataset-label">{{ _("Kind of Activity") }}</th>
-            <td class="dataset-details">{{ h.fao_voc_label('fao_activity_type', pkg_dict.fao_activity_type) }}</td>
+            <td class="dataset-details">
+              <a href="{% url_for controller='package', action='search', fao_activity_type=pkg_dict.fao_activity_type[0], _fao_expanded_facets='fao_activity_type' %}">
+                {{ h.fao_voc_label('fao_activity_type', pkg_dict.fao_activity_type) }}
+              </a>
+            </td>
           </tr>
         {% endif %}
         {% if pkg_dict.fao_geographic_focus %}
           <tr>
             <th scope="row" class="dataset-label">{{ _("Geographic Focus") }}</th>
-            <td class="dataset-details">{{ h.fao_voc_label('fao_geographic_focus', pkg_dict.fao_geographic_focus) }}</td>
+            <td class="dataset-details">
+              <a href="{% url_for controller='package', action='search', fao_geographic_focus=pkg_dict.fao_geographic_focus[0], _fao_expanded_facets='fao_geographic_focus' %}">
+                {{ h.fao_voc_label('fao_geographic_focus', pkg_dict.fao_geographic_focus) }}
+              </a>
+            </td>
           </tr>
         {% endif %}
 


### PR DESCRIPTION
 Expected Behaviour
--------------------
The dataset vocabulary values should be clickable and able to search other datasets with similar vocabularies

What does the Fix:
------------------
- This PR makes dataset vocabularies clickable and able to search for other datasets with similar vocabularies

Changes Made
---------------
-  Changed FAO Specific Info table value to link that directs to the dataset search page with specific vocabulary filtered 

Related Issue
-------------
[issue #94](https://github.com/geosolutions-it/ckanext-faoclh/issues/94)