### PR TITLE
[fixes #124] Number of characters for resource title and description in dataset page

### DIFF
--- a/ckanext/faoclh/public/base/css/main.css
+++ b/ckanext/faoclh/public/base/css/main.css
@@ -16,7 +16,7 @@ article,
 aside,
 details,
 figcaption,
-figure,resource-item
+figure,
 footer,
 header,
 hgroup,

--- a/ckanext/faoclh/public/base/css/main.css
+++ b/ckanext/faoclh/public/base/css/main.css
@@ -16,7 +16,7 @@ article,
 aside,
 details,
 figcaption,
-figure,
+figure,resource-item
 footer,
 header,
 hgroup,
@@ -8365,6 +8365,12 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   color: #000;
   font-size: 14px;
   font-weight: bold;
+}
+.resource-item .description {
+  width: 86%;
+}
+.resource-item .fao-heading {
+  width: 84%;
 }
 .resource-item .format-label {
   position: absolute;

--- a/ckanext/faoclh/templates/package/snippets/resource_item.html
+++ b/ckanext/faoclh/templates/package/snippets/resource_item.html
@@ -1,0 +1,18 @@
+{% ckan_extends %}
+
+{% block resource_item_title %}
+<div class="fao-heading">
+  <a class="heading" href="{{ url }}" title="{{ res.name or res.description }}">
+    {{ h.resource_display_name(res) | truncate(130) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ h.get_translated(res, 'format') }}</span>
+    {{ h.popular('views', res.tracking_summary.total, min=10) }}
+  </a>
+ </div>
+{% endblock %}
+
+{% block resource_item_description %}
+ <p class="description">
+  {% if res.description %}
+    {{ h.markdown_extract(h.get_translated(res, 'description'), extract_length=300) }}
+  {% endif %}
+ </p>
+{% endblock %}


### PR DESCRIPTION
### what does the PR do
- Increases the length of characters in the resource title and description
- Change style to fit the title and description within space not to interfere with the "explore" button

### Relevant screenshots
<img width="1030" alt="Screenshot 2020-10-05 at 19 08 28" src="https://user-images.githubusercontent.com/29429135/95104855-01d4f600-073f-11eb-88c9-f76c770d3dde.png">
