### PR TITLE
[Fixes #129] Change of the share icon in Dataset page

### DIFF
--- a/ckanext/faoclh/templates/snippets/social.html
+++ b/ckanext/faoclh/templates/snippets/social.html
@@ -2,6 +2,10 @@
 
 {% set current_url = h.full_current_url() %}
 
+{% block social_title %}
+  <h2 class="module-heading"><i class="fa fa-share-alt"></i> {{ _('Social') }}</h2>
+{% endblock %}
+
 {% block social_nav %}
     <ul class="nav nav-simple">
         <li class="nav-item"><a href="https://twitter.com/share?url={{ current_url }}" target="_blank"><i class="fa fa-twitter-square"></i> Twitter</a></li>


### PR DESCRIPTION
### What does the PR do?
Changes the share icon in the Dataset detail page and resource detail page

### Relevent screenshots
![Screenshot 2020-10-07 at 18 34 29](https://user-images.githubusercontent.com/29429135/95353323-d2072900-08cb-11eb-8aba-d50cb6dff55e.png)
