### PR TITLE
[fixes #131] Show the entire resource title

### DIFF
--- a/ckanext/faoclh/templates/package/resource_read.html
+++ b/ckanext/faoclh/templates/package/resource_read.html
@@ -1,5 +1,7 @@
 {% ckan_extends %}
 
+        {% block resource_read_title %}<h1 class="page-heading">{{ h.resource_display_name(res) }}</h1>{% endblock %}
+
         {% block resource_additional_information_inner %}
         <div class="module-content">
           <h2>{{ _('Additional Information') }}</h2>


### PR DESCRIPTION
### What does the PR do
- Shows complete resource title on the resource detail page.

### Releveant screenshots
![Screenshot 2020-10-08 at 13 06 06](https://user-images.githubusercontent.com/29429135/95444927-0c71d400-0967-11eb-8040-0bc8c436e903.png)
