### PR TITLE
[Fixes #133] Number of character for resources in resouorce detail page

### DIFF
--- a/ckanext/faoclh/templates/package/snippets/resources.html
+++ b/ckanext/faoclh/templates/package/snippets/resources.html
@@ -1,16 +1,3 @@
-{#
-Displays a sidebard module with navigation containing the provided resources.
-If no resources are provided then the module will not be displayed.
-
-pkg       - The package dict that owns the resources.
-active    - The id of the currently displayed resource.
-action    - The controller action to use (default: 'resource_read').
-
-Example:
-
-  {% snippet "package/snippets/resources.html", pkg=pkg, active=res.id %}
-
-#}
 {% set resources = pkg.resources or [] %}
 {% block resources_list %}
   <ul class="list-unstyled nav nav-simple">

--- a/ckanext/faoclh/templates/package/snippets/resources.html
+++ b/ckanext/faoclh/templates/package/snippets/resources.html
@@ -1,0 +1,23 @@
+{#
+Displays a sidebard module with navigation containing the provided resources.
+If no resources are provided then the module will not be displayed.
+
+pkg       - The package dict that owns the resources.
+active    - The id of the currently displayed resource.
+action    - The controller action to use (default: 'resource_read').
+
+Example:
+
+  {% snippet "package/snippets/resources.html", pkg=pkg, active=res.id %}
+
+#}
+{% set resources = pkg.resources or [] %}
+{% block resources_list %}
+  <ul class="list-unstyled nav nav-simple">
+    {% for resource in resources %}
+      <li class="nav-item{{ ' active' if active == resource.id }}">
+        {% link_for h.resource_display_name(resource)|truncate(40), controller='package', action=action or 'resource_read', id=pkg.name, resource_id=resource.id, inner_span=true %}
+      </li>
+    {% endfor %}
+  </ul>
+{% endblock %}


### PR DESCRIPTION
### What does the PR do
Right column inside the resources detail page: number of characters displayed adjusted to 40.

### Relevant screanshots
![Screenshot 2020-10-08 at 15 31 21](https://user-images.githubusercontent.com/29429135/95458784-56fd4b80-097b-11eb-8c0c-d87cf7cb8bfe.png)
