### PR TITLE
[Fixes #150] Facets remain collapsed in the organisation dataset sear…

### DIFF
--- a/ckanext/faoclh/templates/organization/read.html
+++ b/ckanext/faoclh/templates/organization/read.html
@@ -1,5 +1,10 @@
 {% ckan_extends %}
 
+{% block scripts %}
+  {{ super() }}
+  {% resource 'faoclh/js/fao_facet_list_ui_control.js' %}
+{% endblock %}
+
 {% block organization_facets %}
     <div class="filters">
         <div>


### PR DESCRIPTION
### What does the PR do
- Collapses facet categories in the organization dataset search page 