### PR TITLE
[fixes #149] Clicking the "tags" filters in homepage opens the dataset search page with facets collapsed

### DIFF
--- a/ckanext/faoclh/templates/home/snippets/search.html
+++ b/ckanext/faoclh/templates/home/snippets/search.html
@@ -15,7 +15,7 @@
     <div class="tags">
         <h3>{{ _('Popular tags') }}</h3>
         {% for tag in tags %}
-            <a class="tag" href="{% url_for controller='package', action='search', tags=tag.name %}">{{ h.truncate(tag.display_name, 22) }}</a>
+            <a class="tag" href="{% url_for controller='package', action='search', tags=tag.name, _fao_expanded_facets='tags' %}">{{ h.truncate(tag.display_name, 22) }}</a>
         {% endfor %}
         <a class="tag fao-datasets-tag" href="{{ h.url_for('search') }}"><i class="fa fa-sitemap"></i>&nbsp;{{ _('Datasets') }}</a>
     </div>


### PR DESCRIPTION
### What does the PR do
- Collapses "tag" facets category when a user opens the dataset search page by clicking tags in the home page